### PR TITLE
Force `IS_CHANGED` for easy regeneration in `Grok Image Master`.

### DIFF
--- a/ComfyUI_GrokAI/grok_image_node.py
+++ b/ComfyUI_GrokAI/grok_image_node.py
@@ -118,6 +118,11 @@ class Grok_Image_Master:
     FUNCTION = "generate_master"
     CATEGORY = "xAI/Grok"
 
+    # Force node to always generate
+    @classmethod
+    def IS_CHANGED(cls, **kwargs):
+        return float("NaN")
+
     def generate_master(self, prompt, model, aspect_ratio, resolution, api_key,
                         image=None, mask=None, n=1):
         key = api_key.strip() or os.getenv("XAI_API_KEY", "")


### PR DESCRIPTION
See [IS_CHANGED](https://docs.comfy.org/custom-nodes/backend/server_overview#is_changed).

The previous implementation would not regenerate if none of the inputs changed.

This makes it do the correct behavior of always generating, even if the inputs are the same.

I suggest to also add this to every remote generation node.

EDIT: Now that I think about it, it might be better to make this a toggleable option.